### PR TITLE
refactor random-ipv4addrs.py for faster execution

### DIFF
--- a/random-ipv4addrs.py
+++ b/random-ipv4addrs.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python3
 
-import argparse, random, socket, struct
-
-def long2ipv4addr(num):
-    """
-    Convert a long int to a dotted decimal IPv4 address
-    """
-    return socket.inet_ntoa(struct.pack("!L", num))
+import argparse
+from random import getrandbits
+import socket
+import struct
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-c', type=int, default=10000000)
 args = parser.parse_args()
 
-# TODO: verify we have an integer in the input
-
 for i in range(0, args.c):
-    randnum = int(random.random() * (2**32-1))
-    print(long2ipv4addr(randnum))
+    print(socket.inet_ntoa(struct.pack("!L", getrandbits(32))))

--- a/random-ipv4addrs.py
+++ b/random-ipv4addrs.py
@@ -9,5 +9,5 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-c', type=int, default=10000000)
 args = parser.parse_args()
 
-for i in range(0, args.c):
+for _ in range(0, args.c):
     print(socket.inet_ntoa(struct.pack("!L", getrandbits(32))))


### PR DESCRIPTION
I made the following changes, and am seeing better performance (in my tests) out of this version than the Perl version:

- Migrated from `random.random()` to `random.getrandbits()` which is considerably faster
- Did away with the unnecessary function `long2ipv4addr` to reduce overhead per iteration of the loop

I tested out using `numpy` or other options, but the below was the fastest in my trials.  Here is the output showing ten executions of the Perl variant, the original Python script, and my PR.  In each below test, the "total" value is the equivalent of "real" in other versions of the `time` command.

Perl (Average 7.5893 seconds):

```
$ for i in {1..10};do time ./random-ipv4addrs.pl > /dev/null;done
./random-ipv4addrs.pl > /dev/null  6.03s user 1.53s system 99% cpu 7.563 total
./random-ipv4addrs.pl > /dev/null  6.20s user 1.41s system 99% cpu 7.608 total
./random-ipv4addrs.pl > /dev/null  6.08s user 1.48s system 99% cpu 7.562 total
./random-ipv4addrs.pl > /dev/null  6.12s user 1.46s system 99% cpu 7.576 total
./random-ipv4addrs.pl > /dev/null  6.03s user 1.53s system 99% cpu 7.558 total
./random-ipv4addrs.pl > /dev/null  6.20s user 1.44s system 99% cpu 7.640 total
./random-ipv4addrs.pl > /dev/null  6.09s user 1.47s system 99% cpu 7.554 total
./random-ipv4addrs.pl > /dev/null  6.22s user 1.45s system 99% cpu 7.671 total
./random-ipv4addrs.pl > /dev/null  6.22s user 1.37s system 99% cpu 7.587 total
./random-ipv4addrs.pl > /dev/null  6.22s user 1.35s system 99% cpu 7.574 total
```

Original Python3 (Average 8.7658 seconds):

```
$ for i in {1..10};do time ./random-ipv4addrs-orig.py > /dev/null;done
./random-ipv4addrs-orig.py > /dev/null  8.80s user 0.01s system 99% cpu 8.811 total
./random-ipv4addrs-orig.py > /dev/null  8.83s user 0.00s system 99% cpu 8.830 total
./random-ipv4addrs-orig.py > /dev/null  8.74s user 0.00s system 99% cpu 8.741 total
./random-ipv4addrs-orig.py > /dev/null  8.99s user 0.01s system 99% cpu 8.996 total
./random-ipv4addrs-orig.py > /dev/null  8.53s user 0.01s system 99% cpu 8.542 total
./random-ipv4addrs-orig.py > /dev/null  8.61s user 0.01s system 99% cpu 8.619 total
./random-ipv4addrs-orig.py > /dev/null  8.77s user 0.02s system 99% cpu 8.783 total
./random-ipv4addrs-orig.py > /dev/null  8.73s user 0.01s system 99% cpu 8.736 total
./random-ipv4addrs-orig.py > /dev/null  8.71s user 0.02s system 99% cpu 8.725 total
./random-ipv4addrs-orig.py > /dev/null  8.86s user 0.01s system 99% cpu 8.875 total
```

Modified Python3 (Average 6.669 seconds):

```
$ for i in {1..10};do time ./random-ipv4addrs.py > /dev/null;done
./random-ipv4addrs.py > /dev/null  6.66s user 0.01s system 99% cpu 6.666 total
./random-ipv4addrs.py > /dev/null  6.78s user 0.00s system 99% cpu 6.783 total
./random-ipv4addrs.py > /dev/null  6.60s user 0.01s system 99% cpu 6.614 total
./random-ipv4addrs.py > /dev/null  6.69s user 0.01s system 99% cpu 6.701 total
./random-ipv4addrs.py > /dev/null  6.52s user 0.00s system 99% cpu 6.524 total
./random-ipv4addrs.py > /dev/null  6.52s user 0.00s system 99% cpu 6.522 total
./random-ipv4addrs.py > /dev/null  7.21s user 0.01s system 99% cpu 7.219 total
./random-ipv4addrs.py > /dev/null  6.58s user 0.01s system 99% cpu 6.596 total
./random-ipv4addrs.py > /dev/null  6.50s user 0.02s system 99% cpu 6.511 total
./random-ipv4addrs.py > /dev/null  6.54s user 0.01s system 99% cpu 6.554 total
```