### PR TITLE
Presenting a Go version for your consideration

### DIFF
--- a/random-ipv4addrs.go
+++ b/random-ipv4addrs.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math/rand"
+	"net"
+)
+
+func main() {
+
+	// Parse args for the number of requested random IPv4 Addresses
+	numIPv4AddrsPtr := flag.Int("count", 10000000, "How many addresses do you wish to generate?")
+	flag.Parse()
+
+	// Iterate
+	for i := 0; i < *numIPv4AddrsPtr; i++ {
+		ipByte := make([]byte, 4)
+		binary.BigEndian.PutUint32(ipByte, rand.Uint32())
+		ip := net.IP(ipByte)
+		fmt.Println(ip.String())
+	}
+
+}


### PR DESCRIPTION
Just to see/practice, I wrote it in Go as well.

It is, unsurprisingly, considerably faster.  Averaging just over 6 seconds (even when using `go run random-ipv4addrs.go` and compiling at runtime vs compiling it first.)

Go (Average 6.0411 Seconds):

```
go build random-ipv4addrs.go
for i in {1..10}; do time ./random-ipv4addrs > /dev/null;done
./random-ipv4addrs > /dev/null  4.65s user 1.72s system 105% cpu 6.038 total
./random-ipv4addrs > /dev/null  4.55s user 1.81s system 105% cpu 6.029 total
./random-ipv4addrs > /dev/null  4.81s user 1.61s system 105% cpu 6.080 total
./random-ipv4addrs > /dev/null  4.73s user 1.67s system 105% cpu 6.052 total
./random-ipv4addrs > /dev/null  4.57s user 1.81s system 105% cpu 6.038 total
./random-ipv4addrs > /dev/null  4.68s user 1.70s system 105% cpu 6.042 total
./random-ipv4addrs > /dev/null  4.67s user 1.73s system 105% cpu 6.051 total
./random-ipv4addrs > /dev/null  4.73s user 1.63s system 105% cpu 6.031 total
./random-ipv4addrs > /dev/null  4.56s user 1.81s system 105% cpu 6.033 total
./random-ipv4addrs > /dev/null  4.68s user 1.69s system 105% cpu 6.017 total
```